### PR TITLE
Update workflows to create build as artifact

### DIFF
--- a/.github/workflows/pr-comment-artifact-url.yml
+++ b/.github/workflows/pr-comment-artifact-url.yml
@@ -1,0 +1,70 @@
+# pr-comment-artifact-url.yml
+---
+name: Comment Artifact URL on PR
+
+on:
+  workflow_run:
+    types:
+      - "completed"
+    workflows:
+      - "QA"
+
+jobs:
+  comment-on-pr:
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get Artifact URL & PR Info
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
+          WORKFLOW_RUN_EVENT_OBJ: ${{ toJSON(github.event.workflow_run) }}
+        run: |
+
+          PREVIOUS_JOB_ID=$(jq -r '.id' <<< "$WORKFLOW_RUN_EVENT_OBJ")
+          echo "Previous Job ID: $PREVIOUS_JOB_ID"
+          echo "PREVIOUS_JOB_ID=$PREVIOUS_JOB_ID" >> "$GITHUB_ENV"
+
+          ARTIFACT_URL=$(gh api "/repos/$OWNER/$REPO/actions/artifacts" \
+            --jq ".artifacts.[] |
+            select(.workflow_run.id==${PREVIOUS_JOB_ID}) |
+            select(.expired==false) |
+            .archive_download_url")
+
+          echo "ARTIFACT URL: $ARTIFACT_URL"
+          echo "ARTIFACT_URL=$ARTIFACT_URL" >> "$GITHUB_ENV"
+
+          PR_NUMBER=$(jq -r '.pull_requests[0].number' \
+            <<< "$WORKFLOW_RUN_EVENT_OBJ")
+
+          echo "PR Number: $PR_NUMBER"
+          echo "PR_NUMBER=$PR_NUMBER" >> "$GITHUB_ENV"
+
+          HEAD_SHA=$(jq -r '.pull_requests[0].head.sha' \
+            <<< "$WORKFLOW_RUN_EVENT_OBJ")
+
+          echo "Head sha: $HEAD_SHA"
+          echo "HEAD_SHA=$HEAD_SHA" >> "$GITHUB_ENV"
+
+      - name: Update Comment
+        env:
+          JOB_PATH: "${{ github.server_url }}/${{ github.repository }}/actions/\
+            runs/${{ env.PREVIOUS_JOB_ID }}"
+          HEAD_SHA: ${{ env.HEAD_SHA }}
+        uses: peter-evans/create-or-update-comment@v2
+        with:
+          issue-number: ${{ env.PR_NUMBER }}
+          body: |-
+            ## Build Preview
+            You can find files attached to the below linked Workflow Run URL (Logs).
+
+            Please note that files only stay for around 90 days!
+
+            | Name      | Link
+            --------------------------------------------------------------------
+            | Commit    | ${{ env.HEAD_SHA }}
+
+            | Logs      | ${{ env.JOB_PATH }}
+
+            | Jar Files | ${{ env. ARTIFACT_URL }}

--- a/.github/workflows/pr-comment-artifact-url.yml
+++ b/.github/workflows/pr-comment-artifact-url.yml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   comment-on-pr:
+    if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     steps:
       - name: Get Artifact URL & PR Info

--- a/.github/workflows/pr-comment-artifact-url.yml
+++ b/.github/workflows/pr-comment-artifact-url.yml
@@ -61,10 +61,8 @@ jobs:
 
             Please note that files only stay for around 90 days!
 
-            | Name      | Link
-            --------------------------------------------------------------------
-            | Commit    | ${{ env.HEAD_SHA }}
-
-            | Logs      | ${{ env.JOB_PATH }}
-
-            | APK Files | ${{ env. ARTIFACT_URL }}
+            | Name | Link |
+            |------|------|
+            | Commit | ${{ env.HEAD_SHA }} |
+            | Build Log | ${{ env.JOB_PATH }} |
+            | APK File (Requires OAuth) | ${{ env. ARTIFACT_URL }} |

--- a/.github/workflows/pr-comment-artifact-url.yml
+++ b/.github/workflows/pr-comment-artifact-url.yml
@@ -11,7 +11,6 @@ on:
 
 jobs:
   comment-on-pr:
-    if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     steps:
       - name: Get Artifact URL & PR Info
@@ -67,4 +66,4 @@ jobs:
 
             | Logs      | ${{ env.JOB_PATH }}
 
-            | Jar Files | ${{ env. ARTIFACT_URL }}
+            | APK Files | ${{ env. ARTIFACT_URL }}

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -43,4 +43,7 @@ jobs:
         with:
           file: "app/build/outputs/apk/qa/debug/qa-debug-*.apk"
           overwrite: true
-          draft: true
+          branches: "run-workflows"
+          verbose: true
+          prerelease: true
+          default_release_name: "Test release"

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -36,13 +36,10 @@ jobs:
           sed -i "/qa/,/\}/ s/versionName .*/versionName \"${{github.event.number}}\"/" app/build.gradle
           ./gradlew assembleQaDebug
 
-      - name: Upload release assets
-        uses: xresloader/upload-to-github-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.PERSONAL_TOKEN }}
+      - name: Upload Artifact
+        id: upload
+        uses: actions/upload-artifact@v3
         with:
-          file: "app/build/outputs/apk/qa/debug/qa-debug-*.apk"
-          overwrite: true
-          verbose: true
-          prerelease: true
-          default_release_name: "Test release"
+          name: qa-debug-apk
+          path: "app/build/outputs/apk/qa/debug/qa-debug-*.apk"
+          if-no-files-found: error

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -43,7 +43,6 @@ jobs:
         with:
           file: "app/build/outputs/apk/qa/debug/qa-debug-*.apk"
           overwrite: true
-          branches: "run-workflows"
           verbose: true
           prerelease: true
           default_release_name: "Test release"

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -42,5 +42,5 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           file: "app/build/outputs/apk/qa/debug/qa-debug-*.apk"
-          tags: true
+          overwrite: true
           draft: true

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -1,50 +1,45 @@
 name: "QA"
 
 on:
-    pull_request:
-        branches: [ master, stable-* ]
+  pull_request:
+    branches: [ master, stable-* ]
 
 permissions:
-    pull-requests: write
-    contents: read
+  pull-requests: write
+  contents: read
 
 concurrency: 
-    group: qa-build-${{ github.head_ref || github.run_id }}
-    cancel-in-progress: true
+  group: qa-build-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
-    qa:
-        runs-on: ubuntu-latest
-        steps:
-            -   name: Check if secrets are available
-                run: echo "::set-output name=ok::${{ secrets.KS_PASS != '' }}"
-                id: check-secrets
-            -   uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v3
-                if: ${{ steps.check-secrets.outputs.ok == 'true' }}
-            -   name: set up JDK 17
-                uses: actions/setup-java@387ac29b308b003ca37ba93a6cab5eb57c8f5f93 # v3
-                if: ${{ steps.check-secrets.outputs.ok == 'true' }}
-                with:
-                    distribution: "temurin"
-                    java-version: 17
-            -   name: Install NDK and cmake
-                if: ${{ steps.check-secrets.outputs.ok == 'true' }}
-                run: |
-                    source ndk.env
-                    /usr/local/lib/android/sdk/tools/bin/sdkmanager "ndk;${NDK_VERSION}" "cmake;${CMAKE_VERSION}"
-            -   name: Build QA
-                if: ${{ steps.check-secrets.outputs.ok == 'true' }}
-                env:
-                    KS_PASS: ${{ secrets.KS_PASS }}
-                    KEY_PASS: ${{ secrets.KEY_PASS }}
-                    LOG_USERNAME: ${{ secrets.LOG_USERNAME }}
-                    LOG_PASSWORD: ${{ secrets.LOG_PASSWORD }}
-                    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-                run: |
-                    mkdir -p $HOME/.gradle
-                    echo "org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError" > $HOME/.gradle/gradle.properties
-                    sed -i "/qa/,/\}/ s/versionCode .*/versionCode ${{github.event.number}} /" app/build.gradle
-                    sed -i "/qa/,/\}/ s/versionName .*/versionName \"${{github.event.number}}\"/" app/build.gradle
-                    ./gradlew assembleQaDebug
-                    $(find /usr/local/lib/android/sdk/build-tools/*/apksigner | sort | tail -n1) sign  --ks-pass pass:$KS_PASS --key-pass pass:$KEY_PASS --ks-key-alias key0 --ks scripts/QA_keystore.jks app/build/outputs/apk/qa/debug/qa-debug-*.apk
-                    scripts/uploadArtifact.sh $LOG_USERNAME $LOG_PASSWORD ${{github.event.number}} ${{github.event.number}}
+  qa:
+    runs-on: ubuntu-latest
+    steps:
+      - name: set up JDK 17
+        uses: actions/setup-java@0ab4596768b603586c0de567f2430c30f5b0d2b0 # v3
+        with:
+          distribution: "temurin"
+          java-version: 17
+      - name: Install NDK and cmake
+        run: |
+          source ndk.env
+          /usr/local/lib/android/sdk/tools/bin/sdkmanager "ndk;${NDK_VERSION}" "cmake;${CMAKE_VERSION}"
+      - name: Build QA
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p $HOME/.gradle
+          echo "org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError" > $HOME/.gradle/gradle.properties
+          sed -i "/qa/,/\}/ s/versionCode .*/versionCode ${{github.event.number}} /" app/build.gradle
+          sed -i "/qa/,/\}/ s/versionName .*/versionName \"${{github.event.number}}\"/" app/build.gradle
+          ./gradlew assembleQaDebug
+
+      - name: Upload release assets
+        uses: xresloader/upload-to-github-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          file: "app/build/outputs/apk/qa/debug/qa-debug-*.apk"
+          tags: true
+          draft: true

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -16,6 +16,7 @@ jobs:
   qa:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v3
       - name: set up JDK 17
         uses: actions/setup-java@0ab4596768b603586c0de567f2430c30f5b0d2b0 # v3
         with:

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Upload release assets
         uses: xresloader/upload-to-github-release@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PERSONAL_TOKEN }}
         with:
           file: "app/build/outputs/apk/qa/debug/qa-debug-*.apk"
           overwrite: true

--- a/README.md
+++ b/README.md
@@ -90,4 +90,3 @@ If you need assistance or want to ask a question about the Android app, you are 
 ## Remarks :scroll:
 
 Google Play and the Google Play logo are trademarks of Google Inc.
-

--- a/README.md
+++ b/README.md
@@ -90,3 +90,4 @@ If you need assistance or want to ask a question about the Android app, you are 
 ## Remarks :scroll:
 
 Google Play and the Google Play logo are trademarks of Google Inc.
+


### PR DESCRIPTION
<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->

- Modify QA workflow to build APK and upload as an artifact
- New workflow to create comment linking to artifact files

You can download the artifact using the direct link but it requires OAuth so I would just recommend pulling it from the build log.

Tested here: https://github.com/basharkey/nextcloud-android/pull/3